### PR TITLE
split mega action into many workflows

### DIFF
--- a/.github/workflows/build_release_docs.yml
+++ b/.github/workflows/build_release_docs.yml
@@ -1,0 +1,31 @@
+name: Build and Release Docs to Github Pages
+
+on:
+  push:
+    branches:
+      - master
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: "3.7"
+
+      - name: Install Dependencies
+        run: |
+          pip install --upgrade pip
+          pip install sphinx m2r numpydoc --upgrade
+          python setup.py develop --no-deps
+
+      - name: Build docs
+        run: sphinx-build docs build
+        env:
+          SPHINX_BUILD_PROD: true
+
+      - name: Deploy docs to Github Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          personal_token: ${{ secrets.GH_ACCESS_TOKEN }}
+          publish_dir: ./build

--- a/.github/workflows/push_release_to_pypi.yml
+++ b/.github/workflows/push_release_to_pypi.yml
@@ -1,0 +1,29 @@
+name: Release PyPi Version
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: "3.7"
+
+      - name: Install Dependencies
+        run: |
+          pip install --upgrade pip
+          pip install twine wheel --upgrade
+
+      - name: Build Distribution
+        run: python setup.py sdist bdist_wheel
+
+      - name: Publish Python distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/scheduled_tests.yml
+++ b/.github/workflows/scheduled_tests.yml
@@ -1,6 +1,8 @@
-name: Lint and Test
+name: Scheduled Testing
 
-on: push
+on:
+  schedule:
+    - cron: "0 0 * * 5" # run scheduled tests every friday, in time to ruin my weekend.
 
 jobs:
   run:
@@ -22,23 +24,12 @@ jobs:
           pip install --upgrade pip
 
           # test deps
-          pip install --upgrade black pytest pytest-cov codecov
+          pip install --upgrade pytest
 
           # install deps manually bc pypi numpyro is too strict.
           pip install --upgrade jax jaxlib numpyro tqdm pandas
           pip install git+https://github.com/pyro-ppl/numpyro --no-deps
           python setup.py develop --no-deps
 
-      - name: Lint with Black
-        run: black . --check --verbose
-
       - name: Run unit tests with Pytest
-        run: pytest --verbose --cov=./ --cov-report=xml
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1.0.2
-        with:
-          token: ${{secrets.CODECOV_TOKEN}}
-          name: ${{matrix.python-version}}
-          file: ./coverage.xml
-        continue-on-error: true # I don't care THAT much about codecov
+        run: pytest --verbose

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,12 @@
+{% extends "!layout.html" %}
+{%- block extrahead %}
+{{ super() }}
+<!-- add google analyitcs tracking -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-80719882-1"></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', 'UA-80719882-1');
+</script>
+{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,6 @@ exclude_patterns = []
 html_theme = "classic"
 html_static_path = []
 
-# set up base url in prod env
 if os.getenv("SPHINX_BUILD_PROD"):
     html_baseurl = "https://nolanbconaway.github.io/shabadoo/"
+    templates_path.append("_templates")


### PR DESCRIPTION
Fixing #9 

Splits current workflow into three parts:

1. Lint and test on push to any branch period.
2. Deploy docs to github pages on push to master.
3. Deploy new pypi release each time a github release is created.

Additionally add scheduled testing every friday just so that i might ruin a weekend or two.